### PR TITLE
Add countersink and blind cross-axis hole reconstruction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,52 @@
 # Changelog
 
+## Unreleased
+
+Two new rebuilt feature types, plus a cone-fitting robustness fix that
+made them possible.
+
+### Added
+
+- **Countersunk holes.** A concave cone capping a coaxial drilled
+  cylinder is recognized as a countersink and rebuilt as a
+  `PartDesign::Hole` with `HoleCutType = Countersink` (mouth diameter +
+  included angle). Handles through and blind holes, arbitrary included
+  angles, off-centre and rotated parts, grid patterns, top- and
+  bottom-face machining, and coexistence with plain and counterbored
+  holes. Previously the conical entry of every flat-head-screw hole was
+  fitted but dropped as an unassigned surface.
+- **Blind cross-axis holes.** A side hole that stops inside the part is
+  now rebuilt as a depth-limited `CrossHoleOp` (entry point on the wall,
+  inward direction, drilled depth), cut as a one-sided `Length` pocket.
+  Previously only *through* cross-axis holes were rebuilt; blind ones
+  were reported as unplanned.
+
+### Fixed
+
+- **Cone fitting** could diverge or mis-select on short two-ring cone
+  segments (tessellated countersinks): the half-angle parameter wandered
+  along the periodic residual valley to a wrapped value the `(0, π/2)`
+  guard then rejected, and the normal-based initialization assumed a
+  convex cone, sending concave (hole) cones to a degenerate solution.
+  The half-angle is now recovered from the converged geometry and the
+  axis orientation from the point cloud, so both convex and concave
+  cones fit robustly. Without this, countersink cones were mis-fitted as
+  spheres (two rings lie on a common sphere).
+
+### Docs
+
+- README: countersinks and blind cross-axis holes added to the supported
+  list; corrected the stale note that chamfers are detected-but-not-
+  rebuilt (they are rebuilt as `PartDesign::Chamfer`).
+
+### Tests
+
+- Suite grows from 318 to 379 (all passing), including countersink
+  detection/planning/property-mapping/round-trip, blind cross-hole
+  planning and round-trips, convex/concave cone recovery, and a
+  network-guarded robustness pass over a real machined part
+  (`featuretype.STL`).
+
 ## 0.16.0 (beta) — 2026-07-11
 
 First public beta release.

--- a/README.md
+++ b/README.md
@@ -34,12 +34,16 @@ Recognized and rebuilt on the current beta:
   (detected and labeled, e.g. "8x counterbored hole, grid 4x2").
 - **Counterbored holes**, including bores whose mouth opens *below* the
   part's top face (e.g. on a plate under a raised deck).
-- **Cross-axis holes** (horizontal through-holes).
+- **Countersunk holes**: the conical entry of a flat-head-screw hole is
+  rebuilt as a `PartDesign::Hole` countersink (mouth diameter + included
+  angle), through or blind, on the top or bottom face.
+- **Cross-axis holes** (horizontal holes), both through and blind (a
+  blind side hole is rebuilt as a depth-limited pocket).
 - **Vertical bosses** and **lateral pads** — flanges, rails, and gusseted
   or beveled wedges protruding sideways off a wall, with slanted
   undersides reproduced at true slope.
-- **Fillet detection** with partial rebuild support; **chamfer
-  detection** (reported, not yet rebuilt — see limitations).
+- **Fillet detection** with partial rebuild support, and **chamfer
+  detection and rebuild** as `PartDesign::Chamfer`.
 - **Robust executor**: FreeCAD/OCC boolean failures on individual
   features are retried, deferred to the end of the build, and — only if
   unrecoverable — skipped with a loud, named report instead of silently
@@ -51,12 +55,11 @@ Recognized and rebuilt on the current beta:
 ## Limitations (please read before filing bugs)
 
 - **Prismatic parts only.** The reconstruction targets parts made of
-  planes and cylinders (plates, brackets, housings, fixtures). Organic /
-  sculpted / scanned shapes will not reconstruct meaningfully. Spheres,
-  cones, and tori are fitted by the core but not yet rebuilt as features.
-- **Chamfers and some blends are not rebuilt.** They are detected and
-  listed as "surfaces belonging to no recognized feature"; the rebuilt
-  body has sharp edges there.
+  planes and cylinders (plates, brackets, housings, fixtures), plus
+  conical countersinks. Organic / sculpted / scanned shapes will not
+  reconstruct meaningfully. Spheres and tori are fitted by the core but
+  not yet rebuilt as features; cones are rebuilt only as countersinks
+  (standalone conical faces are not yet a feature).
 - **Dimensional fidelity is bounded by the mesh.** Snapping tolerance is
   ~0.1% of the part diagonal; a coarse tessellation limits what can be
   recovered. Some internal recess boundaries are intentionally oversized

--- a/docs/design-notes.md
+++ b/docs/design-notes.md
@@ -481,6 +481,57 @@ v0.15.6 (lateral pads):
     `scripts/probe_bore_placement.py`, which builds the body and checks each
     bore site).
 
+44. **Cone fitting: recover the half-angle from geometry, not the
+    parameter** (unreleased). A tessellated countersink segments into a short
+    TWO-RING cone frustum, and two rings lie on a common sphere (note 1's
+    impostor), so the sphere wins on vertices unless the cone also fits.
+    Two bugs stopped it. (a) The nonlinear residual `radial·cos α − h·sin α`
+    is PERIODIC in α, so `least_squares` reaches a geometrically-perfect fit
+    (cost ~1e-13) whose α has wrapped to ~1e6°, which the `(0, π/2)` guard
+    then rejects — the surface is right, only the parameter escaped. Fix:
+    after convergence, recover α from the CONVERGED GEOMETRY as the slope of
+    `radial` vs axial height through the apex (`α = atan2(radial·h, h·h)`),
+    ignoring the raw parameter. (b) The normal-based init assumed a CONVEX
+    cone (`n·axis = −sin α < 0`) and force-flipped the axis; a CONCAVE
+    countersink has `n·axis = +sin α > 0`, so the flip sent the optimizer to
+    a degenerate α≈0. Fix: take `α0 = arcsin(|n·axis|)` and orient the axis
+    from the point cloud (apex→centroid), which is correct for both. Bounded
+    `trf` optimization was tried and rejected — it collapses to α≈0. Both
+    fixes are local to `fit_cone`; convex-cone recovery is unchanged to
+    machine precision.
+
+45. **Countersinks are a cone claiming a coaxial drill** (unreleased). A
+    countersunk hole = a concave full-revolution CONE (the entry) coaxial
+    with a drilled CYLINDER, the cone's narrow-end radius matching the drill
+    and its wide rim opening at a face. Detected BEFORE the plain-hole pass
+    (so the drill is described as countersunk, not a bare hole with an
+    orphan cone), then the drill is removed from the concave-cylinder list so
+    no coaxial stack re-claims it. Emitted as a `kind="hole"` feature with
+    `countersink_diameter` + `countersink_angle` (included) and a `mouth`
+    point; drill at `surface_indices[0]` keeps `_side`/`_surface_z`
+    compatible. Through-ness is judged on the COMPOSITE (drill far-opening +
+    cone near-opening), not the drill alone — the drill of a through
+    countersink sees only ONE plane opening because the cone caps its top.
+    Placement uses the mouth, not the drill span: the drill never reaches the
+    mouth face (the cone occupies that band), so `_side`/`_surface_z`
+    special-case countersinks to the `mouth`. Rebuilt natively by
+    `PartDesign::Hole` (`HoleCutType = Countersink`); the pocket fallback
+    does not reproduce the cone (documented degradation for below-top bores).
+
+46. **Blind cross-axis holes are depth-limited cross-hole pockets**
+    (unreleased). Detection was already axis-agnostic (a blind side hole is a
+    horizontal `kind="hole"`, `through=False`); the gap was the planner,
+    whose cross-hole branch fired only for `through=True`, dropping blind
+    side holes to `unplanned`. `CrossHoleOp` gained `through`, `depth`, and
+    `entry_direction`: a blind one carries the ENTRY point on the wall (the
+    axis line pierced through the opening plane), the inward direction
+    (toward the floor plane, or opposite the wall's outward normal), and the
+    drilled depth. The executor cuts it as a one-sided `Length` pocket
+    sketched on the entry wall with the OUTWARD normal (so the default
+    into-material cut drills inward); through holes keep the symmetric
+    midplane pocket. The manifold gate cuts a matching depth-limited bore
+    from each entry point.
+
 ## Run tests
 
 ```

--- a/freecad/meshtofeatures_wb/build.py
+++ b/freecad/meshtofeatures_wb/build.py
@@ -424,16 +424,22 @@ def build_body(doc, plan: BuildPlan, name: str = "Rebuilt"):
 
     doc.recompute()
 
-    # ---- cross-axis through holes: midplane through-all pockets -----------
+    # ---- cross-axis holes: through = midplane pocket, blind = Length -------
     import numpy as np
     for k, ch in enumerate(getattr(plan, "cross_holes", [])):
         axis = np.asarray(ch.axis, dtype=float)
-        u, v = _axis_frame(axis)
+        blind = not getattr(ch, "through", True)
+        # blind holes sketch on the ENTRY wall with the OUTWARD normal, so a
+        # normal (into-material) Length pocket drills inward by the depth;
+        # through holes sketch on a midplane normal to the axis.
+        sn = (-np.asarray(ch.entry_direction, dtype=float)
+              if blind else axis)
+        u, v = _axis_frame(sn)
         anchor0 = np.asarray(ch.positions3d[0], dtype=float)
         m = App.Matrix(
-            float(u[0]), float(v[0]), float(axis[0]), float(anchor0[0]),
-            float(u[1]), float(v[1]), float(axis[1]), float(anchor0[1]),
-            float(u[2]), float(v[2]), float(axis[2]), float(anchor0[2]),
+            float(u[0]), float(v[0]), float(sn[0]), float(anchor0[0]),
+            float(u[1]), float(v[1]), float(sn[1]), float(anchor0[1]),
+            float(u[2]), float(v[2]), float(sn[2]), float(anchor0[2]),
             0.0, 0.0, 0.0, 1.0)
         s = doc.addObject("Sketcher::SketchObject", f"CrossHoleProfile{k}")
         body.addObject(s)
@@ -449,42 +455,49 @@ def build_body(doc, plan: BuildPlan, name: str = "Rebuilt"):
         op = doc.addObject("PartDesign::Pocket", f"CrossHole{k}")
         body.addObject(op)
         op.Profile = s
-        # Cut the through-hole SYMMETRICALLY by an explicit large length each
-        # way (TwoLengths) instead of ThroughAll + Midplane/SideType. The two-
-        # sided handling can misfire on FreeCAD 1.1 (the SideType enum varies)
-        # and cut only ONE direction, leaving a half-cylinder standing at the
-        # far end (field-observed: "the hole is not cut through"). A length of
-        # the body diagonal each way is guaranteed to exit both faces.
-        reach = float(body.Shape.BoundBox.DiagonalLength) or float(L)
-        two_sided = False
-        try:
-            types = list(op.getEnumerationsOfProperty("Type") or [])
-            if "TwoLengths" in types and hasattr(op, "Length2"):
-                op.Type = "TwoLengths"
-                op.Length = reach
-                op.Length2 = reach
-                two_sided = True
-        except Exception:  # noqa: BLE001
-            pass
-        if not two_sided:
-            op.Type = "ThroughAll"
-            # FreeCAD 1.1 deprecates Midplane in favour of SideType; pick the
-            # symmetric/two-sided enum entry by introspection (exact strings
-            # vary across builds), falling back to Midplane on older builds
-            side_set = False
-            if hasattr(op, "SideType"):
-                try:
-                    options = op.getEnumerationsOfProperty("SideType") or []
-                    for want in ("symmetric", "two"):
-                        mm = [o for o in options if want in o.lower()]
-                        if mm:
-                            op.SideType = mm[0]
-                            side_set = True
-                            break
-                except Exception:  # noqa: BLE001
-                    pass
-            if not side_set:
-                op.Midplane = True
+        if blind:
+            # a depth-limited bore from the wall: one-sided Length cut
+            op.Type = "Length"
+            op.Length = float(ch.depth)
+        else:
+            # Cut the through-hole SYMMETRICALLY by an explicit large length
+            # each way (TwoLengths) instead of ThroughAll + Midplane/SideType.
+            # The two-sided handling can misfire on FreeCAD 1.1 (the SideType
+            # enum varies) and cut only ONE direction, leaving a half-cylinder
+            # standing at the far end (field-observed: "the hole is not cut
+            # through"). A length of the body diagonal each way is guaranteed
+            # to exit both faces.
+            reach = float(body.Shape.BoundBox.DiagonalLength) or float(L)
+            two_sided = False
+            try:
+                types = list(op.getEnumerationsOfProperty("Type") or [])
+                if "TwoLengths" in types and hasattr(op, "Length2"):
+                    op.Type = "TwoLengths"
+                    op.Length = reach
+                    op.Length2 = reach
+                    two_sided = True
+            except Exception:  # noqa: BLE001
+                pass
+            if not two_sided:
+                op.Type = "ThroughAll"
+                # FreeCAD 1.1 deprecates Midplane in favour of SideType; pick
+                # the symmetric/two-sided enum entry by introspection (exact
+                # strings vary across builds), falling back to Midplane on
+                # older builds
+                side_set = False
+                if hasattr(op, "SideType"):
+                    try:
+                        options = op.getEnumerationsOfProperty("SideType") or []
+                        for want in ("symmetric", "two"):
+                            mm = [o for o in options if want in o.lower()]
+                            if mm:
+                                op.SideType = mm[0]
+                                side_set = True
+                                break
+                    except Exception:  # noqa: BLE001
+                        pass
+                if not side_set:
+                    op.Midplane = True
         op.Label = ch.label or op.Name
         _apply_refine(op)
         _rollback_if_broken(doc, body, op, s, deferred=deferred)

--- a/meshtofeatures/features.py
+++ b/meshtofeatures/features.py
@@ -124,6 +124,31 @@ def _outer_loop_is_disk_on(surf_plane, cyl: Cylinder, tol: float) -> bool:
     return outer is not None and _loop_on_cylinder(outer, cyl, tol)
 
 
+def _is_concave_cone(surf) -> bool:
+    """Outward face normals of a conical HOLE wall point toward the axis
+    (a countersink), of a conical stud point away from it."""
+    from .primitives import Cone
+    cone: Cone = surf.fit.primitive
+    k = len(surf.segment.face_indices)
+    centroids = surf.segment.samples[:k]
+    v = centroids - cone.apex
+    h = v @ cone.axis
+    radial = v - np.outer(h, cone.axis)
+    n = np.linalg.norm(radial, axis=1, keepdims=True)
+    n[n == 0.0] = 1.0
+    radial /= n
+    return float(np.mean(np.einsum("ij,ij->i",
+                                   surf.segment.face_normals, radial))) < 0.0
+
+
+def _plane_hole_loops_on_cone(surf_plane, cone, tol: float) -> list:
+    """This plane's *interior* hole loops whose points lie on ``cone`` (the
+    conical mouth's wide rim opening at a face)."""
+    _, holes = _split_loops(surf_plane.segment)
+    return [lp for lp in holes
+            if bool(np.all(cone.distance(lp) < tol))]
+
+
 # --------------------------------------------------------------------------
 # detection
 # --------------------------------------------------------------------------
@@ -169,6 +194,9 @@ def detect_features(report: ReconstructionReport,
               if isinstance(s.fit.primitive, Plane)]
     cyls = [i for i, s in enumerate(report.surfaces)
             if isinstance(s.fit.primitive, Cylinder)]
+    from .primitives import Cone
+    cones = [i for i, s in enumerate(report.surfaces)
+             if isinstance(s.fit.primitive, Cone)]
 
     out = FeatureReport()
     consumed: set[int] = set()
@@ -195,6 +223,88 @@ def detect_features(report: ReconstructionReport,
             if _outer_loop_is_disk_on(sp, cyl, tol):
                 floors.append((p, float(np.mean(_axial(sp.segment.points, cyl)))))
         return {"openings": openings, "floors": floors}
+
+    # ---- countersinks: a concave cone capping a coaxial drilled cylinder ---
+    # A countersunk hole is the conical entry (a full-revolution concave
+    # cone) sitting on the opening side of a drilled cylinder: the cone's
+    # wide rim opens at a face, its narrow end matches the drill radius.
+    # Claimed BEFORE the plain-hole pass so the drill is described as a
+    # countersunk hole, not a bare hole with an unassigned cone. The drill
+    # is then removed from the concave list so no coaxial stack re-claims it.
+    from .standards import identify_metric
+    cs_drills: set[int] = set()
+    for ci in cones:
+        scone = report.surfaces[ci]
+        cone = scone.fit.primitive
+        if not patches[ci].full_u or not _is_concave_cone(scone):
+            continue
+        ha = cone.half_angle
+        h_lo, h_hi = patches[ci].v_range          # heights above apex
+        r_narrow = h_lo * np.tan(ha)
+        r_wide = h_hi * np.tan(ha)
+        drill = None
+        for di in full_concave:
+            if di in consumed or di in cs_drills:
+                continue
+            dc = report.surfaces[di].fit.primitive
+            if abs(float(dc.axis @ cone.axis)) < 1.0 - 1e-6:
+                continue                           # not collinear direction
+            off = dc.point - cone.apex
+            perp = off - float(off @ cone.axis) * cone.axis
+            if float(np.linalg.norm(perp)) > 5.0 * tol:
+                continue                           # not the same axis line
+            if abs(dc.radius - r_narrow) > tol + 0.06 * max(dc.radius, r_narrow):
+                continue                           # radius mismatch at throat
+            drill = di
+            break
+        if drill is None:
+            continue
+        dc = report.surfaces[drill].fit.primitive
+        axis = cone.axis.copy()                    # apex -> opening (mouth)
+        dh = (report.surfaces[drill].segment.points - cone.apex) @ axis
+        mouth_h = float(h_hi)
+        mouth = cone.apex + mouth_h * axis
+        dinfo = _ends(drill)
+        through = len(dinfo["openings"]) >= 1
+        depth = mouth_h - float(dh.min())          # mouth -> floor / far face
+        anchor = dc.point - float(dc.point @ dc.axis) * dc.axis
+        used = [drill, ci]
+        for p in planes:
+            if _plane_hole_loops_on_cone(report.surfaces[p], cone, tol) \
+                    and p not in used:
+                used.append(p)
+        for p, _z in dinfo["openings"]:
+            if p not in used:
+                used.append(p)
+        if not through:
+            for p, _z in dinfo["floors"][:1]:
+                if p not in used:
+                    used.append(p)
+        consumed.add(drill)
+        consumed.add(ci)
+        cs_drills.add(drill)
+        std = identify_metric(2 * dc.radius)
+        out.features.append(Feature(
+            kind="hole",
+            surface_indices=used,
+            params={
+                "diameter": 2 * dc.radius,
+                "depth": depth,
+                "through": through,
+                "position": anchor.tolist(),
+                "axis": axis.tolist(),
+                "standard": std,
+                "countersink": True,
+                "countersink_diameter": 2 * r_wide,
+                "countersink_angle": float(np.rad2deg(2 * ha)),
+                "mouth": mouth.tolist(),
+            },
+            description=(
+                f"Countersunk hole d{2 * dc.radius:g} "
+                f"{'through' if through else f'x {depth:g} blind'}, "
+                f"csink d{2 * r_wide:g} x {np.rad2deg(2 * ha):.0f} deg"),
+        ))
+    full_concave = [i for i in full_concave if i not in cs_drills]
 
     # ---- coaxial stacks of concave cylinders -> holes / counterbores ------
     stacks: list[list[int]] = []

--- a/meshtofeatures/fitting.py
+++ b/meshtofeatures/fitting.py
@@ -246,9 +246,9 @@ def fit_cone(points: np.ndarray, normals: np.ndarray | None = None,
 
     if normals is not None and len(normals) > 0:
         nrm = np.atleast_2d(np.asarray(normals, dtype=float))
-        # For an outward-oriented cone, every surface normal satisfies
-        # n . axis = -sin(alpha) (a plane in the Gauss map). Solve
-        # [N | -1] [axis; s] ~= 0 by SVD, normalize so |axis| = 1.
+        # Every cone surface normal satisfies |n . axis| = sin(alpha) (a
+        # pair of planes in the Gauss map). Solve [N | -1] [axis; s] ~= 0 by
+        # SVD, normalize so |axis| = 1.
         M = np.column_stack([nrm, -np.ones(len(nrm))])
         _, _, vt = np.linalg.svd(M, full_matrices=False)
         sol = vt[-1]
@@ -258,15 +258,19 @@ def fit_cone(points: np.ndarray, normals: np.ndarray | None = None,
             raise ValueError("degenerate cone axis estimate")
         s = sol[3] / norm_a
         axis0 = axis0 / norm_a
-        # orient the axis from apex into the opening: with outward normals
-        # n . axis = -sin(alpha) < 0.
-        if s > 0:
-            axis0, s = -axis0, -s
-        alpha0 = float(np.arcsin(np.clip(-s, 1e-3, 1 - 1e-6)))
+        # |n . axis| = sin(alpha) holds for BOTH a convex cone (normals point
+        # away from the axis, n . axis = -sin a) and a CONCAVE one -- a
+        # countersink / conical hole -- whose normals point toward the axis
+        # (n . axis = +sin a). Take the magnitude for the angle and fix the
+        # axis sign from the GEOMETRY (apex -> opening), not from a sign
+        # assumption that only holds for convex cones.
+        alpha0 = float(np.arcsin(np.clip(abs(s), 1e-3, 1 - 1e-6)))
 
         # Apex: every tangent plane passes through it: n_i . (apex - p_i) = 0
         b = np.einsum("ij,ij->i", nrm, pts)
         apex0, *_ = np.linalg.lstsq(nrm, b, rcond=None)
+        if float((pts.mean(axis=0) - apex0) @ axis0) < 0.0:
+            axis0 = -axis0                       # point from apex into opening
     else:
         raise ValueError("cone fitting currently requires normals for initialization")
 
@@ -285,11 +289,24 @@ def fit_cone(points: np.ndarray, normals: np.ndarray | None = None,
 
     x0 = [*apex0, theta0, phi0, alpha0]
     res = least_squares(residuals, x0=x0, method="lm")
-    apex, axis, alpha = unpack(res.x)
-    # normalize parametrization: keep half-angle in (0, pi/2)
-    alpha = float(alpha)
-    if alpha < 0:
-        alpha, axis = -alpha, -axis
+    apex, axis, _alpha_param = unpack(res.x)
+    # Recover the half-angle from the CONVERGED GEOMETRY, not the raw alpha
+    # parameter. The residual radial*cos(a) - h*sin(a) is periodic in a, so
+    # least_squares can reach a geometrically-perfect fit (cost ~ 0) whose a
+    # has wandered far outside (0, pi/2) along that flat valley -- observed
+    # on short two-ring frusta (tessellated countersinks), where the raw a
+    # wrapped to ~1e6 deg and the old (0, pi/2) guard then rejected an
+    # otherwise-correct cone. The true half-angle is the slope of radial
+    # against axial height through the apex: radial = tan(alpha) * h.
+    v = pts - apex
+    h = v @ axis
+    radial = np.linalg.norm(v - np.outer(h, axis), axis=1)
+    if float(np.median(h)) < 0.0:              # orient axis apex -> opening
+        axis, h = -axis, -h
+    hh = float(h @ h)
+    if hh <= 0.0:
+        raise ValueError("degenerate cone: no axial extent")
+    alpha = float(np.arctan2(float(radial @ h), hh))
     if not (0.0 < alpha < np.pi / 2):
         raise ValueError(f"cone fit produced invalid half-angle {alpha}")
     cone = Cone(apex=apex, axis=axis, half_angle=alpha)

--- a/meshtofeatures/history.py
+++ b/meshtofeatures/history.py
@@ -237,6 +237,12 @@ class HoleOp:
     positions: list                 # [(x, y), ...] in the plan frame
     counterbore_diameter: float | None = None
     counterbore_depth: float | None = None
+    #: countersink (conical entry): the mouth diameter and the included
+    #: (full tip) angle in DEGREES. A hole carries at most one of a
+    #: counterbore or a countersink (a counterdrill -- both -- is not yet
+    #: emitted). ``countersink_angle`` defaults the executor to 90 deg.
+    countersink_diameter: float | None = None
+    countersink_angle: float | None = None
     #: blind depth / counterbore measured from the top face (z = length)
     #: when True, from the bottom face (z = 0) when False
     from_top: bool = True
@@ -349,14 +355,21 @@ class ChamferOp:
 
 @dataclass
 class CrossHoleOp:
-    """A THROUGH hole whose axis is not the extrusion direction.
+    """A hole whose axis is not the extrusion direction.
 
-    Carried in WORLD coordinates (3D axis + anchors); the executor cuts a
-    midplane through-all pocket on a sketch normal to the axis."""
+    Carried in WORLD coordinates (3D axis + anchors). A THROUGH hole is cut
+    as a midplane through-all pocket on a sketch normal to the axis. A BLIND
+    hole (``through=False``) is a depth-limited pocket: ``positions3d`` are
+    the ENTRY points on the wall, ``entry_direction`` the unit vector into
+    the part, and ``depth`` the drilled length from the wall to the flat
+    floor."""
     diameter: float
     axis: np.ndarray
     positions3d: list
     label: str = ""
+    through: bool = True
+    depth: float | None = None
+    entry_direction: np.ndarray | None = None
 
 
 @dataclass
@@ -392,12 +405,21 @@ def hole_op_properties(op: HoleOp) -> dict:
         "DrillPoint": "Flat",
         "Threaded": False,
         "Tapered": False,
-        "HoleCutType": "Counterbore" if op.counterbore_diameter else "None",
+        "HoleCutType": "None",
         "Reversed": not op.from_top,
     }
     if not op.through:
         props["Depth"] = float(op.depth)
-    if op.counterbore_diameter:
+    if op.countersink_diameter:
+        # a conical entry: PartDesign::Hole models it by the mouth diameter
+        # plus the included angle (no depth -- the angle and the drill
+        # diameter fix the cone). Takes precedence over a counterbore; a
+        # counterdrill (both) is out of scope.
+        props["HoleCutType"] = "Countersink"
+        props["HoleCutDiameter"] = float(op.countersink_diameter)
+        props["HoleCutCountersinkAngle"] = float(op.countersink_angle or 90.0)
+    elif op.counterbore_diameter:
+        props["HoleCutType"] = "Counterbore"
         props["HoleCutDiameter"] = float(op.counterbore_diameter)
         props["HoleCutDepth"] = float(op.counterbore_depth)
     return props
@@ -605,8 +627,14 @@ def plan_history(report: ReconstructionReport, feats: FeatureReport,
         1); for holes the wall cylinder (index 0). A cut whose axial span
         clings to z = L is machined from the top, to z = 0 from the
         bottom -- the plan frame's z sign is arbitrary, so this must be
-        computed, not assumed.
+        computed, not assumed. A countersunk hole's drill does not reach
+        its mouth (the cone occupies that band), so the mouth face -- not
+        the drill span -- fixes the machining side.
         """
+        if f.params.get("countersink"):
+            mz = float((np.asarray(f.params["mouth"]) - origin) @ z)
+            L = plan.base.length
+            return (L - mz) <= mz
         idx = f.surface_indices[1 if f.kind == "counterbore" else 0]
         hvals = (report.surfaces[idx].segment.points - origin) @ z
         L = plan.base.length
@@ -617,6 +645,8 @@ def plan_history(report: ReconstructionReport, feats: FeatureReport,
         counterbore, drill mouth otherwise), measured from frame_origin. The
         executor places the hole sketch here so a bore whose mouth sits below
         the tallest level is cut inward, not modelled as an outward tower."""
+        if f.params.get("countersink"):
+            return float((np.asarray(f.params["mouth"]) - origin) @ z)
         idx = f.surface_indices[1 if f.kind == "counterbore" else 0]
         hvals = (report.surfaces[idx].segment.points - origin) @ z
         L = plan.base.length
@@ -634,7 +664,50 @@ def plan_history(report: ReconstructionReport, feats: FeatureReport,
             depth=float(spec_params.get("depth", plan.base.length)),
             counterbore_diameter=spec_params.get("counterbore_diameter"),
             counterbore_depth=spec_params.get("counterbore_depth"),
+            countersink_diameter=spec_params.get("countersink_diameter"),
+            countersink_angle=spec_params.get("countersink_angle"),
             positions=positions, label=label, surface_z=surface_z)
+
+    def _cross_hole_op(f):
+        """A non-axis-aligned hole -> CrossHoleOp. A THROUGH hole carries an
+        axis anchor (the executor cuts symmetrically through). A BLIND hole
+        carries the ENTRY point on the wall, the inward direction, and the
+        drilled depth (a one-sided Length pocket)."""
+        axis = np.asarray(f.params["axis"], dtype=float)
+        if f.params.get("through"):
+            return CrossHoleOp(
+                diameter=f.params["diameter"], axis=axis,
+                positions3d=[list(f.params["position"])],
+                through=True, label=f.description)
+        pos = np.asarray(f.params["position"], dtype=float)
+        entry = pos.copy()
+        open_n = None
+        if len(f.surface_indices) > 1:
+            op = report.surfaces[f.surface_indices[1]].fit.primitive
+            if isinstance(op, Plane):
+                open_pt = np.asarray(op.point, dtype=float)
+                open_n = np.asarray(op.normal, dtype=float)
+                denom = float(axis @ open_n)
+                if abs(denom) > 1e-9:              # pierce the wall plane
+                    entry = pos + ((open_pt - pos) @ open_n) / denom * axis
+        # inward direction: toward the floor plane if present, else opposite
+        # the wall's outward normal
+        if len(f.surface_indices) > 2 and isinstance(
+                report.surfaces[f.surface_indices[2]].fit.primitive, Plane):
+            floor_pt = np.asarray(
+                report.surfaces[f.surface_indices[2]].fit.primitive.point,
+                dtype=float)
+            d = float((floor_pt - entry) @ axis)
+        elif open_n is not None:
+            d = -float(open_n @ axis)
+        else:
+            d = 1.0
+        direction = axis * (1.0 if d >= 0 else -1.0)
+        return CrossHoleOp(
+            diameter=f.params["diameter"], axis=axis,
+            positions3d=[list(entry)], through=False,
+            depth=float(f.params["depth"]),
+            entry_direction=list(direction), label=f.description)
 
     # horizontal cylinders protruding beyond the base become circular
     # lateral pads (design note 36); the surfaces they consume are skipped
@@ -648,14 +721,9 @@ def plan_history(report: ReconstructionReport, feats: FeatureReport,
         if any(i in consumed for m in p.members for i in m.surface_indices):
             continue
         kind = p.members[0].kind
-        if kind == "hole" and not _aligned(p.members[0]) \
-                and p.members[0].params.get("through"):
+        if kind == "hole" and not _aligned(p.members[0]):
             for m in p.members:
-                plan.cross_holes.append(CrossHoleOp(
-                    diameter=m.params["diameter"],
-                    axis=np.asarray(m.params["axis"], dtype=float),
-                    positions3d=[list(m.params["position"])],
-                    label=m.description))
+                plan.cross_holes.append(_cross_hole_op(m))
         elif kind in ("hole", "counterbore") and _aligned(p.members[0]):
             plan.holes.append(_hole_op(p.members[0].params,
                                        [_pos2d(m) for m in p.members],
@@ -684,12 +752,8 @@ def plan_history(report: ReconstructionReport, feats: FeatureReport,
             plan.holes.append(_hole_op(f.params, [_pos2d(f)], f.description,
                                        from_top=_side(f),
                                        surface_z=_surface_z(f)))
-        elif f.kind == "hole" and f.params.get("through"):
-            plan.cross_holes.append(CrossHoleOp(
-                diameter=f.params["diameter"],
-                axis=np.asarray(f.params["axis"], dtype=float),
-                positions3d=[list(f.params["position"])],
-                label=f.description))
+        elif f.kind == "hole" and not _aligned(f):
+            plan.cross_holes.append(_cross_hole_op(f))
         elif f.kind == "boss" and _aligned(f):
             hvals = (report.surfaces[f.surface_indices[0]].segment.points
                      - origin) @ z

--- a/scripts/freecad_smoke_test.py
+++ b/scripts/freecad_smoke_test.py
@@ -165,6 +165,29 @@ check("counterbore body volume within 1%",
       f"{cbody.Shape.Volume:.2f} vs {cb_solid.Volume:.2f}")
 check("counterbore body shape is valid", cbody.Shape.isValid())
 
+# --- PartDesign Hole feature (countersunk plate) ----------------------------
+# drill (d5) through a 5 mm plate with a 90 deg countersink to d10 at the top
+cs_solid = Part.makeBox(40, 30, 5, App.Vector(-20, -15, 0)) \
+    .cut(Part.makeCylinder(2.5, 50, App.Vector(0, 0, -20))) \
+    .cut(Part.makeCone(2.5, 5.0, 2.5, App.Vector(0, 0, 2.5)))
+csv, csf = cs_solid.tessellate(0.05)
+cstm = trimesh.Trimesh(vertices=np.array([[v.x, v.y, v.z] for v in csv]),
+                       faces=np.array(csf), process=True)
+csrep = snap_report(reconstruct(cstm)).report
+cspatches = plan_patches(csrep)
+csfeats = detect_features(csrep, cspatches)
+csplan = plan_history(csrep, csfeats, detect_patterns(csfeats), cspatches)
+cscount = [h for h in csplan.holes if h.countersink_diameter]
+check("countersink plan found a countersunk hole", len(cscount) >= 1,
+      f"{len(cscount)} countersunk of {len(csplan.holes)} holes")
+csbody = build.build_body(doc, csplan, name="RebuiltCountersink")
+check("countersink body uses a PartDesign::Hole feature",
+      any(o.TypeId == "PartDesign::Hole" for o in csbody.Group))
+check("countersink body volume within 2%",
+      abs(csbody.Shape.Volume - cs_solid.Volume) / cs_solid.Volume < 0.02,
+      f"{csbody.Shape.Volume:.2f} vs {cs_solid.Volume:.2f}")
+check("countersink body shape is valid", csbody.Shape.isValid())
+
 # --- horizontal fillets rebuilt as PartDesign::Fillet ------------------------
 fp = Part.makeBox(40, 30, 10, App.Vector(-20, -15, 0))
 top_edges = [e for e in fp.Edges
@@ -229,6 +252,26 @@ check("cross-hole body volume within 1%",
       abs(xbody.Shape.Volume - xs.Volume) / xs.Volume < 0.01,
       f"{xbody.Shape.Volume:.2f} vs {xs.Volume:.2f}")
 check("cross-hole body shape is valid", xbody.Shape.isValid())
+
+# --- BLIND cross-axis hole rebuilt as a one-sided Length pocket --------------
+# a d6 hole entering the -x face, drilled 25 mm in (blind, floors inside)
+bxs = Part.makeBox(40, 30, 10, App.Vector(-20, -15, 0)) \
+    .cut(Part.makeCylinder(3.0, 25, App.Vector(-20, 0, 5), App.Vector(1, 0, 0)))
+bxv, bxf = bxs.tessellate(0.05)
+bxtm = trimesh.Trimesh(vertices=np.array([[v.x, v.y, v.z] for v in bxv]),
+                       faces=np.array(bxf), process=True)
+bxrep = snap_report(reconstruct(bxtm)).report
+bxpat = plan_patches(bxrep)
+bxfeats = detect_features(bxrep, bxpat)
+bxplan = plan_history(bxrep, bxfeats, detect_patterns(bxfeats), bxpat)
+bxblind = [c for c in bxplan.cross_holes if not c.through]
+check("blind cross-hole plan carries 1 blind op", len(bxblind) == 1,
+      f"{len(bxblind)} blind of {len(bxplan.cross_holes)} cross-holes")
+bxbody = build.build_body(doc, bxplan, name="RebuiltBlindCrossHole")
+check("blind cross-hole body volume within 2%",
+      abs(bxbody.Shape.Volume - bxs.Volume) / bxs.Volume < 0.02,
+      f"{bxbody.Shape.Volume:.2f} vs {bxs.Volume:.2f}")
+check("blind cross-hole body shape is valid", bxbody.Shape.isValid())
 
 # --- multi-level step part: exercises from-bottom/from-top pocket sides ------
 sp = Part.makeBox(40, 30, 6, App.Vector(-20, -15, 0)) \

--- a/tests/test_adversarial.py
+++ b/tests/test_adversarial.py
@@ -136,6 +136,28 @@ def _rebuild_mesh(plan) -> trimesh.Trimesh:
                 zc = floor + ch / 2 if from_top else floor - ch / 2
                 cb.apply_translation([x, y, zc])
                 solid = solid.difference(cb)
+            if getattr(h, "countersink_diameter", None):
+                # revolve the conical cavity: drill radius at the throat out
+                # to the countersink radius at the mouth face (surface_z).
+                from shapely.geometry import Polygon as _Poly
+                dr = h.diameter / 2.0
+                cr = h.countersink_diameter / 2.0
+                ha = np.deg2rad((h.countersink_angle or 90.0) / 2.0)
+                run = (cr - dr) / np.tan(ha)
+                mouth = sz if from_top else 0.0
+                if from_top:
+                    throat, over = mouth - run, mouth + 1.0
+                    prof = [(0.0, throat), (dr, throat), (cr, mouth),
+                            (cr, over), (0.0, over)]
+                else:
+                    throat, over = mouth + run, mouth - 1.0
+                    # reverse winding so the revolve faces outward (a volume)
+                    prof = [(0.0, over), (cr, over), (cr, mouth),
+                            (dr, throat), (0.0, throat)]
+                tool = trimesh.creation.revolve(
+                    _Poly(prof).exterior.coords, sections=SECTIONS)
+                tool.apply_translation([x, y, 0.0])
+                solid = solid.difference(tool)
     # apply fillets (convex, ~perpendicular blends) via corner-tool cuts;
     # FilletOps live in WORLD coordinates, this solid is in the PLAN
     # frame -- transform each op's geometry into the plan frame first
@@ -153,13 +175,32 @@ def _rebuild_mesh(plan) -> trimesh.Trimesh:
     diag_pf = float(np.linalg.norm(solid.bounds[1] - solid.bounds[0]))
     for ch in getattr(plan, "cross_holes", []):
         axis = vec(ch.axis)
-        cyl = trimesh.creation.cylinder(radius=ch.diameter / 2,
-                                        height=3.0 * diag_pf, sections=96)
-        cyl.apply_transform(trimesh.geometry.align_vectors([0, 0, 1.0], axis))
-        for pos in ch.positions3d:
-            c = cyl.copy()
-            c.apply_translation(loc(pos))
-            solid = solid.difference(c)
+        if getattr(ch, "through", True):
+            cyl = trimesh.creation.cylinder(radius=ch.diameter / 2,
+                                            height=3.0 * diag_pf, sections=96)
+            cyl.apply_transform(
+                trimesh.geometry.align_vectors([0, 0, 1.0], axis))
+            for pos in ch.positions3d:
+                c = cyl.copy()
+                c.apply_translation(loc(pos))
+                solid = solid.difference(c)
+        else:
+            # blind: a depth-limited bore from each ENTRY point along the
+            # inward direction, with a small outward overhang for a clean cut
+            direction = vec(ch.entry_direction)
+            pad = 0.02 * diag_pf
+            length = float(ch.depth) + pad
+            cyl = trimesh.creation.cylinder(radius=ch.diameter / 2,
+                                            height=length, sections=96)
+            cyl.apply_transform(
+                trimesh.geometry.align_vectors([0, 0, 1.0], direction))
+            for pos in ch.positions3d:
+                c = cyl.copy()
+                # cylinder is centred on its axis; shift so it spans from
+                # (entry - pad) to (entry + depth) along the inward direction
+                centre = loc(pos) + (length / 2.0 - pad) * direction
+                c.apply_translation(centre)
+                solid = solid.difference(c)
 
     for co in getattr(plan, "chamfers", []):
         e0, e1 = loc(co.edge_start), loc(co.edge_end)

--- a/tests/test_completeness.py
+++ b/tests/test_completeness.py
@@ -25,7 +25,7 @@ from meshtofeatures.patterns import detect_patterns
 from meshtofeatures.pipeline import reconstruct
 from meshtofeatures.snapping import snap_report
 
-from .test_adversarial import assert_geometry_match, side_drilled_plate
+from .test_adversarial import ROT, assert_geometry_match, side_drilled_plate
 
 pytest.importorskip("manifold3d")
 
@@ -135,8 +135,9 @@ class TestCrossAxisHoles:
         assert len(plan.cross_holes) == 1      # the side hole
         assert_geometry_match(mesh, plan)
 
-    def test_blind_side_holes_stay_unplanned(self):
-        # honesty: only THROUGH cross-axis holes are rebuilt in v0.14
+    def test_blind_side_hole_becomes_a_cross_hole_op(self):
+        # a blind side hole is now rebuilt as a depth-limited CrossHoleOp
+        # (v0.14 left it unplanned; this FLIPS that contract)
         plate = trimesh.creation.box(extents=[40.0, 30.0, 10.0])
         side = trimesh.creation.cylinder(radius=3.0, height=30.0,
                                          sections=SECTIONS)
@@ -145,6 +146,121 @@ class TestCrossAxisHoles:
         side.apply_translation([-15.0, 0.0, 0.0])   # enters -x face, blind
         mesh = plate.difference(side)
         _, feats, plan = _full(mesh)
-        if feats.by_kind("hole"):              # recognized as a blind hole
-            assert plan.cross_holes == []
-            assert plan.unplanned              # reported, not silent
+        holes = feats.by_kind("hole")
+        assert len(holes) == 1
+        assert holes[0].params["through"] is False
+        assert len(plan.cross_holes) == 1
+        ch = plan.cross_holes[0]
+        assert ch.through is False
+        assert np.isclose(ch.diameter, 6.0, atol=0.02)
+        # enters at x=-20; drill (h30 centred at x=-15) floors at x=0 -> 20
+        assert np.isclose(ch.depth, 20.0, atol=0.1)
+        # entry direction points INTO the part (+x from the -x wall)
+        assert float(np.asarray(ch.entry_direction) @ [1.0, 0, 0]) > 0.99
+        assert plan.unplanned == []
+
+    def test_blind_side_hole_roundtrip(self):
+        plate = trimesh.creation.box(extents=[40.0, 30.0, 10.0])
+        side = trimesh.creation.cylinder(radius=3.0, height=30.0,
+                                         sections=SECTIONS)
+        rot = trimesh.transformations.rotation_matrix(np.pi / 2, [0, 1, 0])
+        side.apply_transform(rot)
+        side.apply_translation([-15.0, 0.0, 0.0])
+        mesh = plate.difference(side)
+        _, _, plan = _full(mesh)
+        assert_geometry_match(mesh, plan)
+
+    def test_through_and_blind_side_holes_together(self):
+        plate = trimesh.creation.box(extents=[60.0, 30.0, 10.0])
+        through = trimesh.creation.cylinder(radius=2.0, height=60.0,
+                                            sections=SECTIONS)
+        through.apply_transform(
+            trimesh.transformations.rotation_matrix(np.pi / 2, [0, 1, 0]))
+        through.apply_translation([0.0, 8.0, 0.0])           # y=8, through x
+        blind = trimesh.creation.cylinder(radius=3.0, height=30.0,
+                                          sections=SECTIONS)
+        blind.apply_transform(
+            trimesh.transformations.rotation_matrix(np.pi / 2, [0, 1, 0]))
+        blind.apply_translation([-20.0, -8.0, 0.0])          # enters -x, blind
+        mesh = plate.difference(through).difference(blind)
+        _, _, plan = _full(mesh)
+        assert len(plan.cross_holes) == 2
+        assert sum(c.through for c in plan.cross_holes) == 1
+        assert sum(not c.through for c in plan.cross_holes) == 1
+        assert plan.unplanned == []
+
+    def test_through_and_blind_side_roundtrip(self):
+        plate = trimesh.creation.box(extents=[60.0, 30.0, 10.0])
+        through = trimesh.creation.cylinder(radius=2.0, height=60.0,
+                                            sections=SECTIONS)
+        through.apply_transform(
+            trimesh.transformations.rotation_matrix(np.pi / 2, [0, 1, 0]))
+        through.apply_translation([0.0, 8.0, 0.0])
+        blind = trimesh.creation.cylinder(radius=3.0, height=30.0,
+                                          sections=SECTIONS)
+        blind.apply_transform(
+            trimesh.transformations.rotation_matrix(np.pi / 2, [0, 1, 0]))
+        blind.apply_translation([-20.0, -8.0, 0.0])
+        mesh = plate.difference(through).difference(blind)
+        _, _, plan = _full(mesh)
+        assert_geometry_match(mesh, plan)
+
+    def test_blind_side_hole_from_plus_x(self):
+        # entering the +x face: direction must point -x (inward)
+        plate = trimesh.creation.box(extents=[40.0, 30.0, 10.0])
+        side = trimesh.creation.cylinder(radius=3.0, height=30.0,
+                                         sections=SECTIONS)
+        side.apply_transform(
+            trimesh.transformations.rotation_matrix(np.pi / 2, [0, 1, 0]))
+        side.apply_translation([15.0, 0.0, 0.0])             # enters +x face
+        mesh = plate.difference(side)
+        _, _, plan = _full(mesh)
+        assert len(plan.cross_holes) == 1
+        ch = plan.cross_holes[0]
+        assert ch.through is False
+        assert float(np.asarray(ch.entry_direction) @ [1.0, 0, 0]) < -0.99
+
+    def test_blind_side_hole_on_y_face(self):
+        # a blind hole entering the -y face (axis y), inward = +y
+        plate = trimesh.creation.box(extents=[40.0, 40.0, 10.0])
+        side = trimesh.creation.cylinder(radius=3.0, height=25.0,
+                                         sections=SECTIONS)
+        side.apply_transform(
+            trimesh.transformations.rotation_matrix(np.pi / 2, [1, 0, 0]))
+        side.apply_translation([0.0, -20.0 + 12.5, 0.0])
+        mesh = plate.difference(side)
+        _, _, plan = _full(mesh)
+        assert len(plan.cross_holes) == 1
+        ch = plan.cross_holes[0]
+        assert ch.through is False
+        assert float(np.asarray(ch.entry_direction) @ [0, 1.0, 0]) > 0.99
+
+    def test_blind_side_hole_rotated_roundtrip(self):
+        plate = trimesh.creation.box(extents=[40.0, 30.0, 10.0])
+        side = trimesh.creation.cylinder(radius=3.0, height=25.0,
+                                         sections=SECTIONS)
+        side.apply_transform(
+            trimesh.transformations.rotation_matrix(np.pi / 2, [0, 1, 0]))
+        side.apply_translation([-20.0 + 12.5, 0.0, 0.0])
+        mesh = plate.difference(side).copy()
+        mesh.apply_transform(ROT)
+        _, _, plan = _full(mesh)
+        assert any(not c.through for c in plan.cross_holes)
+        assert_geometry_match(mesh, plan)
+
+    def test_two_blind_side_holes_both_planned(self):
+        plate = trimesh.creation.box(extents=[40.0, 40.0, 10.0])
+        for cy in (-10.0, 10.0):
+            d = trimesh.creation.cylinder(radius=3.0, height=25.0,
+                                          sections=SECTIONS)
+            d.apply_transform(
+                trimesh.transformations.rotation_matrix(np.pi / 2, [0, 1, 0]))
+            d.apply_translation([-20.0 + 12.5, cy, 0.0])
+            plate = plate.difference(d)
+        _, _, plan = _full(plate)
+        # both blind side holes reconstructed (one op with two positions, or
+        # two ops); either way, all blind and nothing dropped
+        total = sum(len(c.positions3d) for c in plan.cross_holes
+                    if not c.through)
+        assert total == 2
+        assert plan.unplanned == []

--- a/tests/test_countersink.py
+++ b/tests/test_countersink.py
@@ -1,0 +1,369 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+"""Countersink tests, written before the implementation.
+
+A countersunk hole is a coaxial CONE (the conical entry) sitting on the
+opening side of a drilled CYLINDER. The cone's wide rim opens at a face;
+its narrow end meets the drill. Recognized as a hole feature carrying
+countersink parameters (diameter, included angle) and rebuilt as a
+PartDesign::Hole with HoleCutType = Countersink.
+
+Geometry facts (verified): for an included angle 2*alpha, the cone's
+half-angle is alpha; the cone radius at axial height h above the apex is
+h*tan(alpha); the narrow end matches the drill radius; the wide rim gives
+the countersink diameter.
+"""
+
+import numpy as np
+import pytest
+import trimesh
+
+pytest.importorskip("manifold3d")
+
+from meshtofeatures.emission import plan_patches
+from meshtofeatures.features import detect_features
+from meshtofeatures.history import HoleOp, hole_op_properties, plan_history
+from meshtofeatures.patterns import detect_patterns
+from meshtofeatures.pipeline import reconstruct
+from meshtofeatures.snapping import snap_report
+
+from .test_adversarial import assert_geometry_match, ROT
+
+SECTIONS = 64
+
+
+# --------------------------------------------------------------- mesh builders
+# A drilled + countersunk hole is a SINGLE revolved cavity (drill up to the
+# throat, cone up to the mouth). Building it as one revolution -- rather than
+# union-ing a separate cylinder and cone -- gives the regular tessellation a
+# real CAD STL export has, instead of a messy boolean seam.
+
+def _revolved_tool(drill_r, csink_r, half_angle_deg, mouth_z, floor_z,
+                   sections=SECTIONS):
+    from shapely.geometry import Polygon
+    ha = np.deg2rad(half_angle_deg)
+    throat_z = mouth_z - (csink_r - drill_r) / np.tan(ha)
+    prof = [(0.0, floor_z), (drill_r, floor_z), (drill_r, throat_z),
+            (csink_r, mouth_z), (0.0, mouth_z)]
+    return trimesh.creation.revolve(Polygon(prof).exterior.coords,
+                                    sections=sections)
+
+
+def countersunk_through_plate(drill_r=2.5, csink_r=5.0, half_angle_deg=45.0,
+                              t=10.0, ext=(40.0, 30.0), center=(0.0, 0.0)):
+    """Plate (z in [-t/2, t/2]) with a countersunk THROUGH hole."""
+    plate = trimesh.creation.box(extents=[ext[0], ext[1], t])
+    tool = _revolved_tool(drill_r, csink_r, half_angle_deg,
+                          t / 2.0, -t / 2.0 - 2.0)
+    tool.apply_translation([center[0], center[1], 0.0])
+    return plate.difference(tool)
+
+
+def countersunk_blind_plate(drill_r=2.5, csink_r=5.0, half_angle_deg=45.0,
+                            t=12.0, depth=8.0, ext=(40.0, 30.0),
+                            center=(0.0, 0.0)):
+    """Plate (z in [-t/2, t/2]) with a countersunk BLIND hole: the drill
+    reaches ``depth`` below the top face, capped by a flat floor."""
+    plate = trimesh.creation.box(extents=[ext[0], ext[1], t])
+    tool = _revolved_tool(drill_r, csink_r, half_angle_deg,
+                          t / 2.0, t / 2.0 - depth)
+    tool.apply_translation([center[0], center[1], 0.0])
+    return plate.difference(tool)
+
+
+def _full(mesh):
+    report = snap_report(reconstruct(mesh)).report
+    patches = plan_patches(report)
+    feats = detect_features(report, patches)
+    plan = plan_history(report, feats, detect_patterns(feats), patches)
+    return report, feats, plan
+
+
+def _only_countersink(feats):
+    cs = [h for h in feats.by_kind("hole") if h.params.get("countersink")]
+    assert len(cs) == 1, f"expected 1 countersink, got {len(cs)}"
+    return cs[0]
+
+
+# ------------------------------------------------------------------ detection
+
+class TestCountersinkDetection:
+    def test_through_countersink_recognized(self):
+        _, feats, _ = _full(countersunk_through_plate())
+        cs = _only_countersink(feats)
+        assert cs.params["through"] is True
+        assert np.isclose(cs.params["diameter"], 5.0, atol=0.05)
+        assert np.isclose(cs.params["countersink_diameter"], 10.0, atol=0.1)
+        assert np.isclose(cs.params["countersink_angle"], 90.0, atol=1.5)
+
+    def test_blind_countersink_recognized(self):
+        _, feats, _ = _full(countersunk_blind_plate(depth=8.0))
+        cs = _only_countersink(feats)
+        assert cs.params["through"] is False
+        assert np.isclose(cs.params["diameter"], 5.0, atol=0.05)
+        assert np.isclose(cs.params["countersink_diameter"], 10.0, atol=0.1)
+        # depth measured from the MOUTH (top face) to the flat floor
+        assert np.isclose(cs.params["depth"], 8.0, atol=0.1)
+
+    @pytest.mark.parametrize("half_angle_deg,included", [
+        (41.0, 82.0), (45.0, 90.0), (50.0, 100.0), (60.0, 120.0)])
+    def test_included_angle_recovered(self, half_angle_deg, included):
+        _, feats, _ = _full(
+            countersunk_through_plate(half_angle_deg=half_angle_deg))
+        cs = _only_countersink(feats)
+        assert np.isclose(cs.params["countersink_angle"], included, atol=2.0)
+
+    @pytest.mark.parametrize("drill_r,csink_r", [
+        (1.5, 3.0), (2.5, 5.0), (3.0, 7.0), (4.0, 8.0)])
+    def test_diameter_ratios(self, drill_r, csink_r):
+        _, feats, _ = _full(countersunk_through_plate(
+            drill_r=drill_r, csink_r=csink_r))
+        cs = _only_countersink(feats)
+        assert np.isclose(cs.params["diameter"], 2 * drill_r, atol=0.05)
+        assert np.isclose(cs.params["countersink_diameter"], 2 * csink_r,
+                          atol=0.15)
+
+    def test_cone_and_drill_both_consumed(self):
+        report, feats, _ = _full(countersunk_through_plate())
+        # nothing conical or the drill cylinder left unassigned
+        from meshtofeatures.primitives import Cone, Cylinder
+        for i in feats.unassigned:
+            prim = report.surfaces[i].fit.primitive
+            assert not isinstance(prim, Cone), "cone left unassigned"
+            assert not isinstance(prim, Cylinder), "drill left unassigned"
+
+    def test_axis_is_vertical(self):
+        _, feats, _ = _full(countersunk_through_plate())
+        cs = _only_countersink(feats)
+        assert abs(float(np.asarray(cs.params["axis"]) @ [0, 0, 1.0])) > 0.999
+
+    def test_offcenter_position(self):
+        _, feats, _ = _full(countersunk_through_plate(center=(8.0, -6.0)))
+        cs = _only_countersink(feats)
+        pos = np.asarray(cs.params["position"])
+        assert np.isclose(pos[0], 8.0, atol=0.1)
+        assert np.isclose(pos[1], -6.0, atol=0.1)
+
+    def test_rotated_part_still_recognized(self):
+        mesh = countersunk_through_plate().copy()
+        mesh.apply_transform(ROT)
+        _, feats, _ = _full(mesh)
+        cs = _only_countersink(feats)
+        assert cs.params["through"] is True
+        assert np.isclose(cs.params["countersink_diameter"], 10.0, atol=0.2)
+
+    def test_countersink_alongside_plain_hole(self):
+        mesh = countersunk_through_plate(center=(-8.0, 0.0))
+        plain = trimesh.creation.cylinder(radius=2.0, height=30.0,
+                                          sections=SECTIONS)
+        plain.apply_translation([10.0, 6.0, 0.0])
+        mesh = mesh.difference(plain)
+        _, feats, _ = _full(mesh)
+        holes = feats.by_kind("hole")
+        cs = [h for h in holes if h.params.get("countersink")]
+        plainh = [h for h in holes if not h.params.get("countersink")]
+        assert len(cs) == 1
+        assert len(plainh) == 1
+        assert np.isclose(plainh[0].params["diameter"], 4.0, atol=0.05)
+
+
+# ------------------------------------------------------- negative / robustness
+
+class TestCountersinkNegatives:
+    def test_plain_hole_has_no_countersink(self):
+        plate = trimesh.creation.box(extents=[40.0, 30.0, 10.0])
+        drill = trimesh.creation.cylinder(radius=3.0, height=30.0,
+                                          sections=SECTIONS)
+        _, feats, _ = _full(plate.difference(drill))
+        holes = feats.by_kind("hole")
+        assert len(holes) == 1
+        assert not holes[0].params.get("countersink")
+
+    def test_chamfered_edge_is_not_a_countersink(self):
+        # a planar edge chamfer must stay a chamfer, never a countersink
+        from .test_completeness import chamfered_top_plate
+        _, feats, _ = _full(chamfered_top_plate())
+        assert not any(h.params.get("countersink")
+                       for h in feats.by_kind("hole"))
+        assert len(feats.by_kind("chamfer")) == 2
+
+
+# ------------------------------------------------- pure property mapping (exec)
+
+class TestCountersinkPropertyMapping:
+    def test_countersink_hole_cut_type(self):
+        op = HoleOp(diameter=5.0, through=True, depth=10.0, positions=[(0, 0)],
+                    countersink_diameter=10.0, countersink_angle=90.0)
+        p = hole_op_properties(op)
+        assert p["HoleCutType"] == "Countersink"
+        assert p["HoleCutDiameter"] == 10.0
+        assert np.isclose(p["HoleCutCountersinkAngle"], 90.0)
+
+    def test_countersink_does_not_leak_counterbore(self):
+        op = HoleOp(diameter=5.0, through=True, depth=10.0, positions=[(0, 0)],
+                    countersink_diameter=10.0, countersink_angle=90.0)
+        p = hole_op_properties(op)
+        assert "HoleCutDepth" not in p        # angle-defined, not depth
+
+    def test_blind_countersink_depth(self):
+        op = HoleOp(diameter=5.0, through=False, depth=8.0, positions=[(0, 0)],
+                    countersink_diameter=10.0, countersink_angle=90.0)
+        p = hole_op_properties(op)
+        assert p["DepthType"] == "Dimension"
+        assert p["Depth"] == 8.0
+        assert p["HoleCutType"] == "Countersink"
+
+
+# -------------------------------------------------------------------- planning
+
+class TestCountersinkPlanning:
+    def test_through_planned_as_hole_op(self):
+        _, _, plan = _full(countersunk_through_plate())
+        assert len(plan.holes) == 1
+        assert plan.unplanned == []
+        op = plan.holes[0]
+        assert op.countersink_diameter is not None
+        assert np.isclose(op.countersink_diameter, 10.0, atol=0.1)
+        assert op.through is True
+
+    def test_blind_planned_as_hole_op(self):
+        _, _, plan = _full(countersunk_blind_plate())
+        assert len(plan.holes) == 1
+        assert plan.unplanned == []
+        op = plan.holes[0]
+        assert op.through is False
+        assert np.isclose(op.depth, 8.0, atol=0.1)
+
+    def test_countersink_and_plain_both_planned(self):
+        mesh = countersunk_through_plate(center=(-8.0, 0.0))
+        plain = trimesh.creation.cylinder(radius=2.0, height=30.0,
+                                          sections=SECTIONS)
+        plain.apply_translation([10.0, 6.0, 0.0])
+        _, _, plan = _full(mesh.difference(plain))
+        assert len(plan.holes) == 2
+        assert sum(op.countersink_diameter is not None
+                   for op in plan.holes) == 1
+        assert plan.unplanned == []
+
+
+# ------------------------------------------------------------------ round-trip
+
+class TestCountersinkRoundtrip:
+    def test_through_roundtrip(self):
+        mesh = countersunk_through_plate()
+        _, _, plan = _full(mesh)
+        assert_geometry_match(mesh, plan)
+
+    def test_blind_roundtrip(self):
+        mesh = countersunk_blind_plate()
+        _, _, plan = _full(mesh)
+        assert_geometry_match(mesh, plan)
+
+    def test_rotated_roundtrip(self):
+        mesh = countersunk_through_plate().copy()
+        mesh.apply_transform(ROT)
+        _, _, plan = _full(mesh)
+        assert_geometry_match(mesh, plan)
+
+    @pytest.mark.parametrize("half_angle_deg", [41.0, 60.0])
+    def test_angle_variants_roundtrip(self, half_angle_deg):
+        mesh = countersunk_through_plate(half_angle_deg=half_angle_deg)
+        _, _, plan = _full(mesh)
+        assert_geometry_match(mesh, plan)
+
+
+# --------------------------------------------------------------- edge cases
+
+def _grid_plate():
+    plate = trimesh.creation.box(extents=[40.0, 40.0, 10.0])
+    for cx in (-10.0, 10.0):
+        for cy in (-10.0, 10.0):
+            tool = _revolved_tool(2.5, 5.0, 45.0, 5.0, -7.0)
+            tool.apply_translation([cx, cy, 0.0])
+            plate = plate.difference(tool)
+    return plate
+
+
+def _bottom_countersink_plate():
+    # a through countersink opening on the BOTTOM face
+    mesh = countersunk_through_plate().copy()
+    mesh.apply_transform(
+        trimesh.transformations.rotation_matrix(np.pi, [1, 0, 0]))
+    return mesh
+
+
+class TestCountersinkEdgeCases:
+    def test_grid_of_countersinks(self):
+        _, feats, plan = _full(_grid_plate())
+        cs = [h for h in feats.by_kind("hole") if h.params.get("countersink")]
+        assert len(cs) == 4
+        # the four identical countersinks collapse into one patterned op
+        csops = [op for op in plan.holes if op.countersink_diameter]
+        assert len(csops) == 1
+        assert len(csops[0].positions) == 4
+        assert plan.unplanned == []
+
+    def test_grid_roundtrip(self):
+        mesh = _grid_plate()
+        _, _, plan = _full(mesh)
+        assert_geometry_match(mesh, plan)
+
+    def test_bottom_face_countersink(self):
+        _, _, plan = _full(_bottom_countersink_plate())
+        assert len(plan.holes) == 1
+        assert plan.holes[0].from_top is False
+        assert np.isclose(plan.holes[0].countersink_diameter, 10.0, atol=0.2)
+
+    def test_bottom_face_roundtrip(self):
+        mesh = _bottom_countersink_plate()
+        _, _, plan = _full(mesh)
+        assert_geometry_match(mesh, plan)
+
+    def test_tiny_countersink(self):
+        plate = trimesh.creation.box(extents=[10.0, 8.0, 3.0])
+        tool = _revolved_tool(0.6, 1.2, 45.0, 1.5, -2.5)
+        _, feats, _ = _full(plate.difference(tool))
+        cs = [h for h in feats.by_kind("hole") if h.params.get("countersink")]
+        assert len(cs) == 1
+        assert np.isclose(cs[0].params["diameter"], 1.2, atol=0.03)
+        assert np.isclose(cs[0].params["countersink_diameter"], 2.4, atol=0.1)
+
+    def test_nonstandard_diameter_not_hallucinated(self):
+        plate = trimesh.creation.box(extents=[40.0, 30.0, 10.0])
+        tool = _revolved_tool(1.85, 4.0, 45.0, 5.0, -7.0)   # d3.7: no standard
+        _, feats, _ = _full(plate.difference(tool))
+        cs = _only_countersink(feats)
+        assert cs.params.get("standard") is None
+
+    def test_countersink_and_counterbore_coexist(self):
+        plate = trimesh.creation.box(extents=[60.0, 30.0, 10.0])
+        tool = _revolved_tool(2.5, 5.0, 45.0, 5.0, -7.0)
+        tool.apply_translation([-15.0, 0.0, 0.0])
+        plate = plate.difference(tool)
+        drill = trimesh.creation.cylinder(radius=2.5, height=40.0,
+                                          sections=SECTIONS)
+        drill.apply_translation([15.0, 0.0, 0.0])
+        bore = trimesh.creation.cylinder(radius=4.5, height=4.0,
+                                         sections=SECTIONS)
+        bore.apply_translation([15.0, 0.0, 3.0])
+        mesh = plate.difference(drill).difference(bore)
+        _, _, plan = _full(mesh)
+        assert sum(op.countersink_diameter is not None
+                   for op in plan.holes) == 1
+        assert sum(op.counterbore_diameter is not None
+                   for op in plan.holes) == 1
+        assert plan.unplanned == []
+
+    def test_countersink_and_counterbore_roundtrip(self):
+        plate = trimesh.creation.box(extents=[60.0, 30.0, 10.0])
+        tool = _revolved_tool(2.5, 5.0, 45.0, 5.0, -7.0)
+        tool.apply_translation([-15.0, 0.0, 0.0])
+        plate = plate.difference(tool)
+        drill = trimesh.creation.cylinder(radius=2.5, height=40.0,
+                                          sections=SECTIONS)
+        drill.apply_translation([15.0, 0.0, 0.0])
+        bore = trimesh.creation.cylinder(radius=4.5, height=4.0,
+                                         sections=SECTIONS)
+        bore.apply_translation([15.0, 0.0, 3.0])
+        mesh = plate.difference(drill).difference(bore)
+        _, _, plan = _full(mesh)
+        assert_geometry_match(mesh, plan)

--- a/tests/test_fitting.py
+++ b/tests/test_fitting.py
@@ -75,6 +75,40 @@ def sample_cone(n=400, noise=0.0):
     return pts, normals, Cone(apex=apex, axis=axis, half_angle=alpha)
 
 
+def sample_cone_frustum(alpha_deg=45.0, r_small=2.5, r_big=5.0, sections=64,
+                        apex=(0.3, -0.4, 0.6), axis=(0.1, 0.2, 1.0),
+                        noise=0.0, concave=False):
+    """A cone frustum sampled as TWO vertex rings -- exactly the vertex
+    pattern a tessellated countersink produces. Two rings lie on a common
+    sphere (the classic impostor of design note 1), and the frustum spans
+    only a short axial band, so the nonlinear cone fit's half-angle
+    parameter can wander far along the periodic residual valley. A robust
+    fitter must still recover the true half-angle.
+
+    ``concave=True`` flips the surface normals to point toward the axis, as
+    a conical HOLE (countersink) does: then n . axis = +sin(alpha), the
+    opposite sign from a convex cone. The fitter must handle both."""
+    apex = np.asarray(apex, dtype=float)
+    axis = np.asarray(axis, dtype=float); axis /= np.linalg.norm(axis)
+    alpha = np.deg2rad(alpha_deg)
+    u = np.cross(axis, [1.0, 0.0, 0.0]); u /= np.linalg.norm(u)
+    v = np.cross(axis, u)
+    theta = np.linspace(0.0, 2 * np.pi, sections, endpoint=False)
+    ring = np.cos(theta)[:, None] * u + np.sin(theta)[:, None] * v
+    t = np.tan(alpha)
+    sign = -1.0 if concave else 1.0
+    pts, normals = [], []
+    for r in (r_small, r_big):
+        h = r / t
+        pts.append(apex + h * axis + r * ring)
+        normals.append(sign * (ring * np.cos(alpha) - axis * np.sin(alpha)))
+    pts = np.vstack(pts)
+    normals = np.vstack(normals)
+    if noise:
+        pts = pts + noise * RNG.normal(size=pts.shape)
+    return pts, normals, Cone(apex=apex, axis=axis, half_angle=alpha)
+
+
 def assert_same_direction(a, b, atol=1e-6):
     assert np.isclose(abs(np.dot(a, b)), 1.0, atol=atol), f"{a} vs {b}"
 
@@ -169,6 +203,65 @@ class TestFitCone:
         assert np.isclose(fit.primitive.half_angle, truth.half_angle, atol=5e-3)
         assert np.allclose(fit.primitive.apex, truth.apex, atol=0.05)
 
+    @pytest.mark.parametrize("alpha_deg", [20.0, 30.0, 41.0, 45.0, 50.0, 60.0])
+    def test_frustum_two_rings_recovers_half_angle(self, alpha_deg):
+        # a short two-ring frustum (a real tessellated countersink) must not
+        # let the half-angle wander to a wrapped/degenerate value
+        pts, normals, truth = sample_cone_frustum(alpha_deg=alpha_deg)
+        fit = fit_cone(pts, normals)
+        assert isinstance(fit.primitive, Cone)
+        assert np.isclose(fit.primitive.half_angle, truth.half_angle, atol=1e-4)
+        # axis points apex -> opening
+        assert np.dot(fit.primitive.axis, truth.axis) > 0.9999
+        # the surface itself is recovered (distance to true-cone samples ~ 0)
+        assert fit.rms < 1e-6
+
+    def test_frustum_noisy(self):
+        pts, normals, truth = sample_cone_frustum(alpha_deg=41.0, noise=0.003)
+        fit = fit_cone(pts, normals)
+        assert np.isclose(fit.primitive.half_angle, truth.half_angle, atol=5e-3)
+
+    @pytest.mark.parametrize("alpha_deg", [30.0, 45.0, 60.0])
+    def test_concave_cone_recovered(self, alpha_deg):
+        # a conical HOLE: normals point toward the axis (n . axis = +sin a),
+        # the opposite sign from a convex cone. The init must not assume a
+        # sign; recovery must still give the true half-angle and an axis
+        # pointing apex -> opening.
+        pts, normals, truth = sample_cone_frustum(alpha_deg=alpha_deg,
+                                                  concave=True)
+        fit = fit_cone(pts, normals)
+        assert np.isclose(fit.primitive.half_angle, truth.half_angle,
+                          atol=1e-4)
+        assert np.dot(fit.primitive.axis, truth.axis) > 0.9999
+        assert fit.rms < 1e-6
+
+    @pytest.mark.parametrize("half_angle_deg", [30.0, 41.0, 45.0, 60.0])
+    def test_real_countersink_mesh_recognizes_cone(self, half_angle_deg):
+        # end-to-end regression pin: a tessellated countersunk hole segments
+        # into a short two-ring cone whose averaged normals send the raw
+        # nonlinear fit's half-angle wandering. Before the geometry-based
+        # recovery the conical wall was mis-selected as a Sphere (its two
+        # rings lie on a common sphere); it must be a Cone now.
+        pytest.importorskip("trimesh")
+        import trimesh
+        from meshtofeatures.pipeline import reconstruct
+        plate = trimesh.creation.box(extents=[40.0, 30.0, 10.0])
+        drill = trimesh.creation.cylinder(radius=2.5, height=30.0, sections=64)
+        ha = np.deg2rad(half_angle_deg)
+        h_wide = 5.0 / np.tan(ha)
+        cone = trimesh.creation.cone(radius=5.0, height=h_wide, sections=64)
+        cone.apply_transform(
+            trimesh.transformations.rotation_matrix(np.pi, [1, 0, 0]))
+        cone.apply_translation([0, 0, 5.0])          # wide rim at top face
+        mesh = plate.difference(drill.union(cone))
+        rep = reconstruct(mesh)
+        kinds = [s.fit.primitive.kind for s in rep.surfaces]
+        assert "cone" in kinds, f"no cone recognized; got {kinds}"
+        cones = [s.fit.primitive for s in rep.surfaces
+                 if s.fit.primitive.kind == "cone"]
+        assert any(np.isclose(c.half_angle, ha, atol=np.deg2rad(1.5))
+                   for c in cones)
+
 
 # ---------------------------------------------------------------- selection
 
@@ -188,6 +281,22 @@ class TestFitBest:
     def test_cone_wins_on_cone(self):
         pts, normals, _ = sample_cone()
         assert fit_best(pts, normals).primitive.kind == "cone"
+
+    def test_cone_wins_on_two_ring_frustum(self):
+        # the two rings lie on a common sphere (design note 1); dense
+        # samples on the true surface must still select the cone
+        pts, normals, truth = sample_cone_frustum(alpha_deg=45.0)
+        # score on dense surface samples between the rings (expose the sphere)
+        u = np.cross(truth.axis, [1.0, 0.0, 0.0]); u /= np.linalg.norm(u)
+        v = np.cross(truth.axis, u)
+        th = RNG.uniform(0, 2 * np.pi, 500)
+        r = RNG.uniform(2.5, 5.0, 500)
+        h = r / np.tan(truth.half_angle)
+        samples = (truth.apex + h[:, None] * truth.axis
+                   + r[:, None] * (np.cos(th)[:, None] * u
+                                   + np.sin(th)[:, None] * v))
+        assert fit_best(pts, normals,
+                        score_points=samples).primitive.kind == "cone"
 
     def test_plane_preferred_over_giant_sphere(self):
         # noisy plane: a huge sphere fits noisy planar data almost as well;

--- a/tests/test_real_stl.py
+++ b/tests/test_real_stl.py
@@ -1,0 +1,80 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+"""Robustness tests on real STL parts pulled from the trimesh model repo.
+
+These are integration smoke tests: a real machined part must flow through
+the whole pipeline without error, and the new feature passes (cone fitting,
+countersink detection, blind cross-hole planning) must not false-positive on
+geometry that has none of those features. Network-guarded: skipped offline.
+"""
+
+import io
+import urllib.request
+
+import numpy as np
+import pytest
+import trimesh
+
+pytest.importorskip("manifold3d")
+
+from meshtofeatures.emission import plan_patches
+from meshtofeatures.features import detect_features
+from meshtofeatures.history import plan_history
+from meshtofeatures.patterns import detect_patterns
+from meshtofeatures.pipeline import reconstruct
+from meshtofeatures.snapping import snap_report
+
+_BASE = "https://raw.githubusercontent.com/mikedh/trimesh/main/models/"
+
+
+def _load(name):
+    try:
+        with urllib.request.urlopen(_BASE + name, timeout=20) as r:
+            data = r.read()
+    except Exception as exc:                       # noqa: BLE001 - offline CI
+        pytest.skip(f"could not fetch {name}: {exc}")
+    ext = name.rsplit(".", 1)[-1].lower()
+    mesh = trimesh.load(io.BytesIO(data), file_type=ext)
+    if isinstance(mesh, trimesh.Scene):
+        mesh = mesh.dump(concatenate=True)
+    return mesh
+
+
+def _full(mesh):
+    report = snap_report(reconstruct(mesh)).report
+    patches = plan_patches(report)
+    feats = detect_features(report, patches)
+    plan = plan_history(report, feats, detect_patterns(feats), patches)
+    return report, feats, plan
+
+
+class TestFeatureTypeStl:
+    """featuretype.STL: a prismatic machined part (holes, counterbores,
+    fillets, pockets) -- but NO conical features."""
+
+    def test_pipeline_runs_and_covers(self):
+        mesh = _load("featuretype.STL")
+        report, feats, plan = _full(mesh)
+        assert report.coverage > 0.95
+        # a plan is produced with real features and nothing silently dropped
+        assert (plan.holes or plan.pockets or plan.cross_holes)
+        assert plan.unplanned == []
+
+    def test_no_spurious_countersinks(self):
+        # the part has no cones; the countersink pass must not invent any
+        mesh = _load("featuretype.STL")
+        report, feats, _ = _full(mesh)
+        assert not any(s.fit.primitive.kind == "cone"
+                       for s in report.surfaces)
+        assert not any(h.params.get("countersink")
+                       for h in feats.by_kind("hole"))
+
+    def test_no_spurious_blind_cross_holes(self):
+        # every planned cross-hole must be geometrically justified: a blind
+        # one must carry a positive depth and a unit entry direction
+        mesh = _load("featuretype.STL")
+        _, _, plan = _full(mesh)
+        for ch in plan.cross_holes:
+            if not ch.through:
+                assert ch.depth is not None and ch.depth > 0
+                d = np.asarray(ch.entry_direction, dtype=float)
+                assert np.isclose(np.linalg.norm(d), 1.0, atol=1e-6)


### PR DESCRIPTION
Two new rebuilt feature types plus the cone-fitting robustness fix that made them possible. No version bump (kept at 0.16.0).

Countersinks: a concave cone capping a coaxial drilled cylinder is recognized and rebuilt as a PartDesign::Hole with HoleCutType=Countersink (mouth diameter + included angle). Through/blind, arbitrary angles, off-centre/rotated parts, grid patterns, top/bottom-face machining, and coexistence with plain and counterbored holes.

Blind cross-axis holes: a side hole that stops inside the part is rebuilt as a depth-limited CrossHoleOp (entry point, inward direction, depth), cut as a one-sided Length pocket. Previously left unplanned.

fit_cone fix: recover the half-angle from the converged geometry (the residual is periodic in alpha, so lm reaches a perfect fit whose alpha wrapped outside (0, pi/2)); make the normal-based init orientation- agnostic so concave (hole) cones no longer collapse. Without this, countersink cones were mis-fitted as spheres.

Tests: 318 -> 379, all passing, zero regressions, incl. a network-guarded robustness pass over featuretype.STL. Docs: README/CHANGELOG (Unreleased)/ design-notes updated; corrected the stale note that chamfers aren't rebuilt.